### PR TITLE
Add explicit foreign key columns to use when saving new entities to tables

### DIFF
--- a/backend/src/models/department.entity.ts
+++ b/backend/src/models/department.entity.ts
@@ -10,12 +10,18 @@ export class Department {
     name: string
 
     @OneToOne(() => Position)
-    @JoinColumn()
+    @JoinColumn({ name: "departmentHeadId" })
     departmentHead: Position
+
+    @Column({ type: "int", nullable: true })
+    departmentHeadId: number
 
     @OneToOne(() => Position)
     @JoinColumn()
     leadershipTeamMember: Position
+
+    @Column({ type: "int", nullable: true})
+    leadershipTeamMemberId: number
 
     @OneToMany(() => Position, (position) => position.manager)
     employees: Position[]

--- a/backend/src/models/department.entity.ts
+++ b/backend/src/models/department.entity.ts
@@ -17,7 +17,7 @@ export class Department {
     departmentHeadId: number
 
     @OneToOne(() => Position)
-    @JoinColumn()
+    @JoinColumn({ name: "leadershipTeamMemberId"})
     leadershipTeamMember: Position
 
     @Column({ type: "int", nullable: true})

--- a/backend/src/models/form.entity.ts
+++ b/backend/src/models/form.entity.ts
@@ -14,8 +14,11 @@ export class Form {
     pdfLink: string
 
     @OneToOne(() => SignatureChainLink, (signatureChainLink) => signatureChainLink.form)
-    @JoinColumn()
+    @JoinColumn({ name: "signatureChainLinkHeadId" })
     signatureChainLinkHead: SignatureChainLink
+
+    @Column({ type: "int", nullable: true })
+    signatureChainLinkHeadId: number
 
     @OneToMany(() => FormInstance, (formInstance) => formInstance.formType)
     formInstances: FormInstance[]

--- a/backend/src/models/formInstance.entity.ts
+++ b/backend/src/models/formInstance.entity.ts
@@ -15,9 +15,16 @@ export class FormInstance {
     completed: boolean
 
     @OneToOne(() => SignatureRequestLink)
-    @JoinColumn()
+    @JoinColumn({ name: "signatureRequestHeadId"})
     signatureRequestHead: SignatureRequestLink
 
+    @Column({ type: "int", nullable: true })
+    signatureRequestHeadId: number
+
     @ManyToOne(() => Position, (position) => position.formInstances)
+    @JoinColumn({ name: "initiatorId"})
     initiator: Position
+
+    @Column({ type: "int", nullable: true })
+    initiatorId: number
 }

--- a/backend/src/models/position.entity.ts
+++ b/backend/src/models/position.entity.ts
@@ -12,17 +12,28 @@ export class Position {
     roleName: string
 
     @ManyToOne(() => Position, (position) => position.underlings)
+    @JoinColumn({ name: "managerId"})
     manager: Position
+
+    @Column({ type: "int", nullable: true })
+    managerId: number
 
     @OneToMany(() => Position, (position) => position.manager)
     underlings: Position[]
 
     @ManyToOne(() => Department, (department) => department.employees)
+    @JoinColumn({ name: "departmentId"})
     department: Department
 
+    @Column({ type: "int", nullable: true })
+    departmentId: number
+
     @OneToOne(() => Employee)
-    @JoinColumn()
+    @JoinColumn({ name: "employeeId" })
     employee: Employee
+
+    @Column({ type: "int", nullable: true })
+    employeeId: number
 
     @OneToMany(() => FormInstance, (formInstance) => formInstance.initiator)
     formInstances: FormInstance[]

--- a/backend/src/models/signatureChainLink.entity.ts
+++ b/backend/src/models/signatureChainLink.entity.ts
@@ -14,10 +14,16 @@ export class SignatureChainLink {
     position: SigningPositions
 
     @ManyToOne(() => Position)
+    @JoinColumn({ name: "specificPositionId"})
     specificPosition: Position
 
+    @Column({ type: "int", nullable: true })
+    specificPositionid: number
+
     @OneToOne(() => SignatureChainLink)
-    @JoinColumn()
+    @JoinColumn({ name: "nextSignatureId"})
     nextSignature: SignatureChainLink
 
+    @Column({ type: "int", nullable: true })
+    nextSignatureId: number
 }

--- a/backend/src/models/signatureRequestLink.entity.ts
+++ b/backend/src/models/signatureRequestLink.entity.ts
@@ -15,7 +15,11 @@ export class SignatureRequestLink {
     formInstance: FormInstance
 
     @ManyToOne(() => Position)
+    @JoinColumn({ name: "positionId"})
     position: Position
+
+    @Column({ type: "int", nullable: true })
+    positionId: number
 
     @Column()
     isSigned: boolean
@@ -24,7 +28,9 @@ export class SignatureRequestLink {
     canSign: boolean
 
     @OneToOne(() => SignatureRequestLink)
-    @JoinColumn()
+    @JoinColumn({ name: "nextId" })
     next: SignatureRequestLink
 
+    @Column({ type: "int", nullable: true })
+    nextId: number
 }


### PR DESCRIPTION
This PR adds explicit foreign key columns in order to allow services to save new entities with foreign key references by using the foreign key id values instead of the full referenced foreign entity. This issue arose when we were creating services/entity repositories - this solution means we won't have to query for the foreign entity separately just to save another entity to a table.

Closes [Create database schema for backend](https://trello.com/c/ynAzefkR/6-create-database-schema-for-backend)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verify all tables and their schemas by manually checking each table's schema after setting up the DB by running `yarn start:dev`

# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
