### PR TITLE
Env port

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NextJS, NestJS, Prisma, PostgreSQL
 
 ## Overview of Yarn Commands
 
-- `dev`: start the frontend
+- `dev`: start the frontend and backend (hot reloading)
 - `format`: run prettier formatter
 - `lint`: run eslint
 - `test`: run all tests
@@ -24,37 +24,37 @@ NextJS, NestJS, Prisma, PostgreSQL
 1. Create a .env file in `apps/web` and `apps/server` and configure environment variables using the provided example files.
 2. Install yarn dependencies. We currently use Yarn and Yarn workspaces to manage dependencies.
 
-    ```bash
-    yarn install
-    ```
+   ```bash
+   yarn install
+   ```
 
 3. Generate the Prisma Client in the `apps/server` directory using the following command from within the `apps/server` directory:
 
-    ```bash
-    yarn prisma generate
-    ```
+   ```bash
+   yarn prisma generate
+   ```
 
-4. Start up your local backend and database stack:
+4. Start up your local database:
 
-    ```bash
-    yarn backend:docker:run
-    ```
+   ```bash
+   yarn dev:db:up
+   ```
 
 5. Migrate your local database using Prisma Migrate in order to set up database schemas.
 
-    ```bash
-    yarn migrate
-    ```
+   ```bash
+   yarn migrate
+   ```
 
-6. Run the frontend client locally. The environment variables should be configured to use our local stack:
+6. Run the frontend and backend locally. The environment variables should be configured to use our local stack:
 
-    ```bash
-    yarn dev
-    ```
+   ```bash
+   yarn dev
+   ```
 
-    The client should be hosted at [http://localhost:3000](http://localhost:3000).
+   The client should be hosted at [http://localhost:3000](http://localhost:3000).
 
-    The server should be hosted at [http://localhost:8080](http://localhost:8080).
+   The server should be hosted at [http://localhost:8080](http://localhost:8080).
 
 7. The database should be located at [http://localhost:5432](http://localhost:5432). pgadmin is accessible from [http://localhost:5050](http://localhost:5050), and the credentials are `admin@admin.com:pgadmin4`. To connect to the database using pgadmin, create a new server connection with the host set to `host.docker.internal`, port set to `5432`, and username and password set to `user` and `pass` respectively.
 
@@ -64,14 +64,14 @@ When making changes to our backend, we need to regenerate our frontend client to
 
 1. Start instance of backend server hosted at [http://localhost:4000](http://localhost:4000) by running the following command in the server directory:
 
-    ```bash
-    yarn backend:docker:up
-    ```
+   ```bash
+   yarn dev
+   ```
 
 2. Run the following command:
 
-    ```bash
-    yarn gen-client
-    ```
+   ```bash
+   yarn gen-client
+   ```
 
-    The client should be regenerated based on the running local backend instance.
+   The client should be regenerated based on the running local backend instance.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.1.8",

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { SignaturesModule } from './signatures/signatures.module';
 import { FormInstancesModule } from './form-instances/form-instances.module';
 import { FormTemplatesModule } from './form-templates/form-templates.module';
 import { DepartmentsModule } from './departments/departments.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -20,6 +21,9 @@ import { DepartmentsModule } from './departments/departments.module';
     FormInstancesModule,
     FormTemplatesModule,
     DepartmentsModule,
+    ConfigModule.forRoot({
+      envFilePath: '.env',
+    })
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
+
   const app = await NestFactory.create(AppModule);
 
   app.useGlobalPipes(new ValidationPipe());
@@ -21,4 +22,5 @@ async function bootstrap() {
 
   await app.listen(process.env.PORT || 4000);
 }
+
 bootstrap();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apps/web"
   ],
   "scripts": {
-    "dev": "yarn --cwd apps/web dev",
+    "dev": "yarn --cwd apps/web dev && yarn --cwd apps/server start:dev",
     "format": "yarn workspaces run prettier . --write",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apps/web"
   ],
   "scripts": {
-    "dev": "yarn --cwd apps/web dev && yarn --cwd apps/server start:dev",
+    "dev": "yarn --cwd apps/web dev & yarn --cwd apps/server start:dev",
     "format": "yarn workspaces run prettier . --write",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test --passWithNoTests",


### PR DESCRIPTION
## Description/Problem

yarn start:dev didn't like my .env file and defaulted to port 4000.

## Solution

Added ConfigModule to the imports in AppModule and specified the env file path to the .env file in the server directory.
Requires running yarn install.

## Dependencies

[x] This PR adds new dependencies

## Testing

Tested manually using yarn start:dev and seeing which port the backend started on.
  