### PR TITLE
Add routes to get form instances for current user

### DIFF
--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -126,6 +126,34 @@ async function fetchSignatureFields(
   return signatureFieldsMap;
 }
 
+// type definition for mapping signature field names (ex: 'Director', 'Manager') to their data
+type FormInstanceData = {
+  id: string;
+  name: string;
+  formDocLink: string;
+  originatorId: string;
+  formTemplateId: string;
+  signatures: any[];
+};
+
+// upsert new form instances
+async function upsertFormInstance(formInstanceData: FormInstanceData) {
+  const { id, name, formDocLink, originatorId, formTemplateId, signatures } =
+    formInstanceData;
+  await prisma.formInstance.create({
+    data: {
+      id: id,
+      name: name,
+      formDocLink: formDocLink,
+      originatorId: originatorId,
+      formTemplateId: formTemplateId,
+      signatures: {
+        create: signatures,
+      },
+    },
+  });
+}
+
 /* main seeding function to upsert the following data: 
 - 1 form template 
 - 1 department (leadership team) 
@@ -228,6 +256,61 @@ async function main() {
   for (const empData of employees) {
     await upsertEmployee(empData);
   }
+
+  // form instances
+  const formInstances = [
+    {
+      id: '855498f1-0a8c-44a8-8159-26e28ab8eca0',
+      name: 'First Form Instance',
+      formDocLink: 'mfa.org',
+      originatorId: '777c1974-3104-4744-ae31-7a9296e7784a',
+      formTemplateId: '1fbccd8a-b00c-472f-a94f-defa8e86e0cf',
+      signatures: [
+        {
+          id: '86e14052-f953-4188-8188-933511d0b1ea',
+          order: 0,
+          signerPositionId: CHIEF_LEARNING_ENGAGEMENT_UUID,
+        },
+        {
+          id: 'd4ecf386-1e43-427e-803b-cbb216d84ec5',
+          order: 1,
+          signerPositionId: AGG_DIR_UUID,
+        },
+      ],
+    },
+    {
+      id: '1c50e8ed-b6d7-4205-bfd7-dce825c63040',
+      name: 'Second Form Instance',
+      formDocLink: 'mfa.org',
+      originatorId: '777c1974-3104-4744-ae31-7a9296e7784a',
+      formTemplateId: '1fbccd8a-b00c-472f-a94f-defa8e86e0cf',
+      signatures: [
+        {
+          id: '6dadcc5a-06eb-4822-b20c-a53f0978b8c0',
+          order: 0,
+          signerPositionId: CHIEF_LEARNING_ENGAGEMENT_UUID,
+        },
+      ],
+    },
+    {
+      id: '0affdf33-3c4b-42bf-99af-8ef47d231f41',
+      name: 'Third Form Instance',
+      formDocLink: 'mfa.org',
+      originatorId: '339cf78e-d13f-4069-b1f7-dee0c64afb31',
+      formTemplateId: '1fbccd8a-b00c-472f-a94f-defa8e86e0cf',
+      signatures: [
+        {
+          id: '6f104e9b-27db-4c39-9668-acd7e533e115',
+          order: 0,
+          signerPositionId: AGG_DIR_UUID,
+        },
+      ],
+    },
+  ];
+
+  for (const formInstance of formInstances) {
+    await upsertFormInstance(formInstance);
+  }
 }
 
 // runs main seeding function
@@ -260,6 +343,9 @@ main()
 
     const allSignatureFields = await prisma.signatureField.findMany();
     console.log('Signature Fields:', allSignatureFields);
+
+    const allFormInstances = await prisma.formInstance.findMany();
+    console.log('Form Instances:', allFormInstances);
 
     await prisma.$disconnect();
   });

--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -140,15 +140,17 @@ type FormInstanceData = {
 async function upsertFormInstance(formInstanceData: FormInstanceData) {
   const { id, name, formDocLink, originatorId, formTemplateId, signatures } =
     formInstanceData;
-  await prisma.formInstance.create({
-    data: {
-      id: id,
-      name: name,
-      formDocLink: formDocLink,
-      originatorId: originatorId,
-      formTemplateId: formTemplateId,
+  await prisma.formInstance.upsert({
+    where: { id },
+    update: {},
+    create: {
+      id,
+      name,
+      formDocLink,
+      originatorId,
+      formTemplateId,
       signatures: {
-        create: signatures,
+        connect: signatures,
       },
     },
   });

--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -6,14 +6,12 @@ import {
   ApiUnprocessableEntityResponse,
   ApiBadRequestResponse,
   ApiBody,
-  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AppErrorMessage } from './app.errors';
 import { JwtEntity } from './auth/entities/jwt.entity';
 import { LocalAuthGuard } from './auth/guards/local-auth.guard';
 import { EmployeeEntity } from './employees/entities/employee.entity';
 import { AuthService } from './auth/auth.service';
-import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 @Controller()
 export class AppController {
@@ -22,9 +20,7 @@ export class AppController {
     private authService: AuthService,
   ) {}
 
-  @UseGuards(JwtAuthGuard)
   @Get()
-  @ApiBearerAuth()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/apps/server/src/auth/auth.decorators.ts
+++ b/apps/server/src/auth/auth.decorators.ts
@@ -1,0 +1,9 @@
+import { SetMetadata, createParamDecorator } from '@nestjs/common';
+import { UserEntity } from './entities/user.entity';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);
+
+export const AuthUser = createParamDecorator((data, req) => {
+  return new UserEntity(req.args[0].user);
+});

--- a/apps/server/src/auth/entities/user.entity.ts
+++ b/apps/server/src/auth/entities/user.entity.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserEntity {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  email: string;
+
+  constructor(partial: Partial<UserEntity>) {
+    Object.assign(this, partial);
+  }
+}

--- a/apps/server/src/auth/public.decorator.ts
+++ b/apps/server/src/auth/public.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common';
-
-export const IS_PUBLIC_KEY = 'isPublic';
-export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/server/src/employees/entities/employee.entity.ts
+++ b/apps/server/src/employees/entities/employee.entity.ts
@@ -3,7 +3,7 @@ import { Employee } from '@prisma/client';
 import { PositionEntity } from './../../positions/entities/position.entity';
 import { Exclude } from 'class-transformer';
 
-export class EmployeeEntity implements Employee {
+export class EmployeeBaseEntity implements Employee {
   @ApiProperty()
   id: string;
 
@@ -17,9 +17,6 @@ export class EmployeeEntity implements Employee {
   positionId: string;
 
   @ApiProperty()
-  position: PositionEntity;
-
-  @ApiProperty()
   email: string;
 
   @Exclude()
@@ -31,7 +28,17 @@ export class EmployeeEntity implements Employee {
   @Exclude()
   updatedAt: Date;
 
+  constructor(partial: Partial<EmployeeBaseEntity>) {
+    Object.assign(this, partial);
+  }
+}
+
+export class EmployeeEntity extends EmployeeBaseEntity {
+  @ApiProperty()
+  position: PositionEntity;
+
   constructor(partial: Partial<EmployeeEntity>) {
+    super(partial);
     if (partial.position) {
       partial.position = new PositionEntity(partial.position);
     }

--- a/apps/server/src/form-instances/entities/form-instance.entity.ts
+++ b/apps/server/src/form-instances/entities/form-instance.entity.ts
@@ -49,6 +49,11 @@ export class FormInstanceEntity implements FormInstance {
     if (partial.originator) {
       partial.originator = new EmployeeEntity(partial.originator);
     }
+    if (partial.signatures) {
+      partial.signatures = partial.signatures.map(
+        (signature) => new SignatureEntity(signature),
+      );
+    }
 
     Object.assign(this, partial);
   }

--- a/apps/server/src/form-instances/form-instances.service.spec.ts
+++ b/apps/server/src/form-instances/form-instances.service.spec.ts
@@ -9,27 +9,63 @@ const formInstance3Id = 'formInstanceId3';
 const formInstance1Name = 'Form-Instance-1';
 const formInstance2Name = 'Form-Instance-2';
 const formInstance3Name = 'Form-Instance-3';
-const originatorId = 'originatorId';
-const originator = {
-  id: originatorId,
+const departmentId = 'departmentId';
+const department = {
+  id: departmentId,
+  name: 'Archives',
+  createdAt: new Date(1672531200),
+  updatedAt: new Date(1672531200),
+};
+const positionId1 = 'positionId1';
+const positionId2 = 'positionId2';
+const positionId3 = 'positionId3';
+const position1 = {
+  id: positionId1,
+  name: 'Manager',
+  single: true,
+  departmentId: departmentId,
+  department: department,
+  createdAt: new Date(1672531200),
+  updatedAt: new Date(1672531200),
+};
+const position2 = {
+  id: positionId2,
+  name: 'Senior Manager',
+  single: true,
+  departmentId: departmentId,
+  department: department,
+  createdAt: new Date(1672531200),
+  updatedAt: new Date(1672531200),
+};
+const position3 = {
+  id: positionId3,
+  name: 'Associate',
+  single: true,
+  departmentId: departmentId,
+  department: department,
+  createdAt: new Date(1672531200),
+  updatedAt: new Date(1672531200),
+};
+const originatorId1 = 'originatorId1';
+const originatorId2 = 'originatorId2';
+const originator1 = {
+  id: originatorId1,
   firstName: 'First',
   lastName: 'Last',
-  positionId: 'positionId',
-  position: {
-    id: 'positionId',
-    name: 'Manager',
-    single: true,
-    departmentId: 'departmentId',
-    department: {
-      id: 'departmentId',
-      name: 'Archives',
-      createdAt: new Date(1672531200),
-      updatedAt: new Date(1672531200),
-    },
-    createdAt: new Date(1672531200),
-    updatedAt: new Date(1672531200),
-  },
-  email: 'info@mfa.org',
+  positionId: positionId1,
+  position: position1,
+  email: 'info1@mfa.org',
+  pswdHash: 'password',
+  createdAt: new Date(1672531200),
+  updatedAt: new Date(1672531200),
+};
+const originator2 = {
+  id: originatorId2,
+  firstName: 'Also First',
+  lastName: 'And Last',
+  positionId: positionId2,
+  position: position2,
+  email: 'info2@mfa.org',
   pswdHash: 'password',
   createdAt: new Date(1672531200),
   updatedAt: new Date(1672531200),
@@ -42,6 +78,10 @@ const formTemplate = {
   createdAt: new Date(1672531200),
   updatedAt: new Date(1672531200),
 };
+const signatureId1 = 'signatureId1';
+const signatureId2 = 'signatureId1';
+const signatureId3 = 'signatureId1';
+const signatureId4 = 'signatureId1';
 
 const formInstancesArray = [
   {
@@ -51,33 +91,33 @@ const formInstancesArray = [
     completed: false,
     createdAt: new Date(1672531200),
     updatedAt: new Date(1672531200),
-    originatorId: originatorId,
-    originator: originator,
+    originatorId: originatorId1,
+    originator: originator1,
     formTemplateId: formTemplateId,
     formTemplate: formTemplate,
     signatures: [
       {
-        id: 'signatureId1',
+        id: signatureId1,
         order: 0,
         signed: false,
         signedDocLink: null,
         createdAt: new Date(1672531200),
         updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
+        signerPositionId: positionId3,
+        signerPosition: position3,
         userSignedById: null,
         userSignedBy: null,
         formInstanceId: formInstance1Id,
       },
       {
-        id: 'signatureId2',
+        id: signatureId2,
         order: 1,
         signed: false,
         signedDocLink: null,
         createdAt: new Date(1672531200),
         updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
+        signerPositionId: positionId2,
+        signerPosition: position2,
         userSignedById: null,
         userSignedBy: null,
         formInstanceId: formInstance1Id,
@@ -91,33 +131,20 @@ const formInstancesArray = [
     completed: false,
     createdAt: new Date(1672531200),
     updatedAt: new Date(1672531200),
-    originatorId: originatorId,
-    originator: originator,
+    originatorId: originatorId1,
+    originator: originator1,
     formTemplateId: formTemplateId,
     formTemplate: formTemplate,
     signatures: [
       {
-        id: 'signatureId1',
+        id: signatureId3,
         order: 0,
         signed: false,
         signedDocLink: null,
         createdAt: new Date(1672531200),
         updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
-        userSignedById: null,
-        userSignedBy: null,
-        formInstanceId: formInstance2Id,
-      },
-      {
-        id: 'signatureId2',
-        order: 1,
-        signed: false,
-        signedDocLink: null,
-        createdAt: new Date(1672531200),
-        updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
+        signerPositionId: positionId3,
+        signerPosition: position3,
         userSignedById: null,
         userSignedBy: null,
         formInstanceId: formInstance2Id,
@@ -131,33 +158,20 @@ const formInstancesArray = [
     completed: false,
     createdAt: new Date(1672531200),
     updatedAt: new Date(1672531200),
-    originatorId: originatorId,
-    originator: originator,
+    originatorId: originatorId2,
+    originator: originator2,
     formTemplateId: formTemplateId,
     formTemplate: formTemplate,
     signatures: [
       {
-        id: 'signatureId1',
+        id: signatureId4,
         order: 0,
         signed: false,
         signedDocLink: null,
         createdAt: new Date(1672531200),
         updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
-        userSignedById: null,
-        userSignedBy: null,
-        formInstanceId: formInstance3Id,
-      },
-      {
-        id: 'signatureId2',
-        order: 1,
-        signed: false,
-        signedDocLink: null,
-        createdAt: new Date(1672531200),
-        updatedAt: new Date(1672531200),
-        signerPositionId: null,
-        signerPosition: null,
+        signerPositionId: positionId1,
+        signerPosition: position1,
         userSignedById: null,
         userSignedBy: null,
         formInstanceId: formInstance3Id,
@@ -229,6 +243,51 @@ describe('FormInstancesService', () => {
       expect(service.create(createFormInstanceDto)).resolves.toEqual(
         oneFormInstance,
       );
+    });
+  });
+
+  // WORK IN PROGRESS
+  // describe('findAssignedTo', () => {
+  //   beforeEach(async () => {
+  //     db.formInstance.findMany = jest
+  //       .fn()
+  //       .mockResolvedValue(
+  //         formInstancesArray.slice(formInstancesArray.length - 1),
+  //       );
+  //   });
+
+  //   it('should successfully find all form instances assigned to an employee', () => {
+  //     expect(service.findAssignedTo(originatorId2)).resolves.toEqual(
+  //       formInstancesArray.slice(formInstancesArray.length - 1),
+  //     );
+  //   });
+
+  //   afterEach(async () => {
+  //     db.formInstance.findMany = jest
+  //       .fn()
+  //       .mockResolvedValue(formInstancesArray);
+  //   });
+  // });
+
+  describe('findCreatedBy', () => {
+    beforeEach(async () => {
+      db.formInstance.findMany = jest
+        .fn()
+        .mockResolvedValue(
+          formInstancesArray.slice(formInstancesArray.length - 1),
+        );
+    });
+
+    it('should successfully find all form instances created by an employee', () => {
+      expect(service.findCreatedBy(originatorId2)).resolves.toEqual(
+        formInstancesArray.slice(formInstancesArray.length - 1),
+      );
+    });
+
+    afterEach(async () => {
+      db.formInstance.findMany = jest
+        .fn()
+        .mockResolvedValue(formInstancesArray);
     });
   });
 

--- a/apps/server/src/form-instances/form-instances.service.ts
+++ b/apps/server/src/form-instances/form-instances.service.ts
@@ -40,9 +40,79 @@ export class FormInstancesService {
       include: {
         originator: true,
         formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
       },
     });
     return newFormInstance;
+  }
+
+  async findAssignedTo(employeeId: string) {
+    const formInstances = await this.prisma.formInstance.findMany({
+      where: {
+        signatures: {
+          some: {
+            signerPosition: {
+              employees: {
+                some: {
+                  id: {
+                    equals: employeeId,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      include: {
+        originator: true,
+        formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
+      },
+    });
+    return formInstances;
+  }
+
+  async findCreatedBy(employeeId: string) {
+    const formInstances = await this.prisma.formInstance.findMany({
+      where: {
+        originatorId: {
+          equals: employeeId,
+        },
+      },
+      include: {
+        originator: true,
+        formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
+      },
+    });
+    return formInstances;
   }
 
   async findAll(limit?: number) {
@@ -51,6 +121,16 @@ export class FormInstancesService {
       include: {
         originator: true,
         formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
       },
     });
     return formInstances;
@@ -64,6 +144,16 @@ export class FormInstancesService {
       include: {
         originator: true,
         formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
       },
     });
     return formInstance;
@@ -83,6 +173,16 @@ export class FormInstancesService {
       include: {
         originator: true,
         formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
       },
     });
     return updatedFormInstance;
@@ -96,6 +196,16 @@ export class FormInstancesService {
       include: {
         originator: true,
         formTemplate: true,
+        signatures: {
+          include: {
+            signerPosition: {
+              include: {
+                department: true,
+              },
+            },
+            userSignedBy: true,
+          },
+        },
       },
     });
   }

--- a/apps/server/src/form-templates/dto/create-form-template.dto.ts
+++ b/apps/server/src/form-templates/dto/create-form-template.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { CreateSignatureFieldDto } from '../../signature-fields/dto/create-signature-field.dto';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsString,
+  IsUrl,
+} from 'class-validator';
 
 export class CreateFormTemplateDto {
   @IsString()
@@ -12,4 +19,9 @@ export class CreateFormTemplateDto {
   @IsUrl()
   @ApiProperty()
   formDocLink: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ApiProperty()
+  signatureFields: CreateSignatureFieldDto[];
 }

--- a/apps/server/src/form-templates/dto/update-form-template.dto.ts
+++ b/apps/server/src/form-templates/dto/update-form-template.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateFormTemplateDto } from './create-form-template.dto';
 
-export class UpdateFormTemplateDto extends PartialType(CreateFormTemplateDto) {}
+export class UpdateFormTemplateDto extends PartialType(
+  OmitType(CreateFormTemplateDto, ['signatureFields'] as const),
+) {}

--- a/apps/server/src/form-templates/form-templates.service.ts
+++ b/apps/server/src/form-templates/form-templates.service.ts
@@ -17,6 +17,7 @@ export class FormTemplatesService {
       data: {
         name: createFormTemplateDto.name,
         formDocLink: createFormTemplateDto.formDocLink,
+        signatureFields: { create: createFormTemplateDto.signatureFields },
       },
     });
     return newFormTemplate;

--- a/apps/server/src/signatures/entities/signature.entity.ts
+++ b/apps/server/src/signatures/entities/signature.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Signature } from '@prisma/client';
-import { EmployeeEntity } from '../../employees/entities/employee.entity';
+import { EmployeeBaseEntity } from '../../employees/entities/employee.entity';
 import { PositionEntity } from '../../positions/entities/position.entity';
 import { Exclude } from 'class-transformer';
 
@@ -33,7 +33,7 @@ export class SignatureEntity implements Signature {
   userSignedById: string | null;
 
   @ApiProperty()
-  userSignedBy: EmployeeEntity | null;
+  userSignedBy: EmployeeBaseEntity | null;
 
   @Exclude()
   formInstanceId: string;
@@ -43,7 +43,7 @@ export class SignatureEntity implements Signature {
       partial.signerPosition = new PositionEntity(partial.signerPosition);
     }
     if (partial.userSignedBy) {
-      partial.userSignedBy = new EmployeeEntity(partial.userSignedBy);
+      partial.userSignedBy = new EmployeeBaseEntity(partial.userSignedBy);
     }
 
     Object.assign(this, partial);

--- a/apps/web/src/client/models/CreateFormTemplateDto.ts
+++ b/apps/web/src/client/models/CreateFormTemplateDto.ts
@@ -6,5 +6,6 @@
 export type CreateFormTemplateDto = {
     name: string;
     formDocLink: string;
+    signatureFields: Array<string>;
 };
 

--- a/apps/web/src/client/models/EmployeeEntity.ts
+++ b/apps/web/src/client/models/EmployeeEntity.ts
@@ -9,7 +9,7 @@ export type EmployeeEntity = {
     id: string;
     firstName: string;
     lastName: string;
-    position: PositionEntity;
     email: string;
+    position: PositionEntity;
 };
 

--- a/apps/web/src/client/services/FormInstancesService.ts
+++ b/apps/web/src/client/services/FormInstancesService.ts
@@ -54,6 +54,36 @@ export class FormInstancesService {
     }
 
     /**
+     * @returns FormInstanceEntity
+     * @throws ApiError
+     */
+    public static formInstancesControllerFindAllAssignedToCurrentEmployee(): CancelablePromise<Array<FormInstanceEntity>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/form-instances/me',
+            errors: {
+                400: `Bad Request`,
+                403: `Unauthorized Request`,
+            },
+        });
+    }
+
+    /**
+     * @returns FormInstanceEntity
+     * @throws ApiError
+     */
+    public static formInstancesControllerFindAllCreatedByCurrentEmployee(): CancelablePromise<Array<FormInstanceEntity>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/form-instances/created/me',
+            errors: {
+                400: `Bad Request`,
+                403: `Unauthorized Request`,
+            },
+        });
+    }
+
+    /**
      * @param id
      * @returns FormInstanceEntity
      * @throws ApiError


### PR DESCRIPTION
## Description/Problem

Closes [Add authentication/create routes to fetch form instances for a specific employee](https://trello.com/c/xu9kRUKm/58-add-authentication-create-routes-to-fetch-form-instances-for-a-specific-employee)

Added /me routes for form instances to get instances for currently authenticated user.
Added seeding for form instances
Partial unit test coverage.

## Solution

^

## Dependencies

[ ] This PR adds new dependencies

## Testing

Please describe how you tested this PR (manually and/or automatically)
Provide instructions so we can reproduce, and include screenshots of UI changes.

- Manual Tests?
  - Try authenticating and testing out the `/form-instance/me` and `/form-instance/created/me` routes using the accounts `email1@gmail.com` and `email2@gmail.com` in the Swagger API.
- Unit/Integration/E2E Tests?
  - CI passing
  