### PR TITLE
Fix form cards text

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/apps/web/src/components/FormCard.tsx
+++ b/apps/web/src/components/FormCard.tsx
@@ -18,8 +18,8 @@ export const FormCard = ({
   return (
     <>
       <Box
-        w="246px"
-        h="120px"
+        minW="246px"
+        minH="120px"
         borderRadius="5px"
         backgroundColor="#FFFFFF"
         boxShadow="0px 0.5px 3px 1px #D4D4D4"

--- a/apps/web/src/components/FormCard.tsx
+++ b/apps/web/src/components/FormCard.tsx
@@ -32,8 +32,8 @@ export const FormCard = ({
           boxShadow: '0px 0.5px 6px 1px #D4D4D4',
         }}
       >
-        <Box paddingLeft="24px" paddingTop="26px">
-          <Text fontFamily="Hanken Grotesk" fontWeight={800} fontSize="18px">
+        <Box padding="24px" paddingTop="26px">
+          <Text fontFamily="Hanken Grotesk" fontWeight={800} fontSize="18px" isTruncated>
             {formName}
           </Text>
           {/*Dummy values until userSignedBy fixed*/}

--- a/apps/web/src/components/OverviewRow.tsx
+++ b/apps/web/src/components/OverviewRow.tsx
@@ -24,7 +24,7 @@ export const OverviewRow = ({
   );
   return (
     <>
-      <Box width={rowWidth}>
+      <Box w={rowWidth}>
         <Flex justifyContent="space-between" alignItems="center">
           <Flex alignItems="center">
             <Text fontSize="22px" fontWeight="800">

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -22,11 +22,11 @@ export default function Overview() {
   if (assignedFIError || createdFIError) return <Error />;
 
   const rowWidth = Math.max(
-    230 * 1.5,
+    260 * 1.5,
     Math.min(
       4,
       Math.max(todoForms.length, pendingForms.length, completedForms.length),
-    ) * 230,
+    ) * 260,
   );
 
   return (


### PR DESCRIPTION
## Description/Problem

Closes [story](https://trello.com/c/FwYiPTGw/118-fix-form-instance-cards-truncate-title-card-sizing)

Form cards text is lopsided when too long.

## Solution

Truncate form cards text when too long.

## Dependencies

[ ] This PR adds new dependencies

## Testing

Made some really long form texts and they were truncated.