### PR TITLE
Fix todo to reflect forms that are ready to be signed

### DIFF
--- a/apps/web/src/hooks/useForm.ts
+++ b/apps/web/src/hooks/useForm.ts
@@ -64,13 +64,7 @@ export const useForm = () => {
           return false;
         }
         
-        // If the first unsigned signature is the current user, return true
-        if (firstUnsignedSignature.signerPositionId === user.positionId) {
-          return true;
-        }
-
-        // Otherwise, return false
-        return false;
+        return firstUnsignedSignature.signerPositionId === user.positionId;
       },
     );
 

--- a/apps/web/src/hooks/useForm.ts
+++ b/apps/web/src/hooks/useForm.ts
@@ -48,10 +48,23 @@ export const useForm = () => {
     const todoForms: FormInstanceEntity[] = assignedFIData.filter(
       (formInstance: FormInstanceEntity) => {
         const signatures: SignatureEntity[] = formInstance.signatures;
-        for (let i = 0; i < signatures.length; i++) {
-          if (signatures[i].signerPositionId === user.positionId) {
-            return signatures[i].signed === false;
-          }
+
+        // Filter out signatures that are already signed
+        signatures.filter((signature: SignatureEntity) => {
+          return signature.signed === false;
+        });
+
+        // Sort signatures by order
+        signatures.sort((a: SignatureEntity, b: SignatureEntity) => {
+          return a.order - b.order;
+        });
+
+        // Get next signature
+        const nextSignature: SignatureEntity = signatures[0];
+
+        // If next signature is current user, then this form is a todo
+        if (nextSignature.signerPositionId === user.positionId) {
+          return true;
         }
       },
     );

--- a/apps/web/src/hooks/useForm.ts
+++ b/apps/web/src/hooks/useForm.ts
@@ -49,23 +49,28 @@ export const useForm = () => {
       (formInstance: FormInstanceEntity) => {
         const signatures: SignatureEntity[] = formInstance.signatures;
 
-        // Filter out signatures that are already signed
-        signatures.filter((signature: SignatureEntity) => {
-          return signature.signed === false;
-        });
-
         // Sort signatures by order
         signatures.sort((a: SignatureEntity, b: SignatureEntity) => {
           return a.order - b.order;
         });
 
-        // Get next signature
-        const nextSignature: SignatureEntity = signatures[0];
+        // Find the first signature that doesn't have a signature
+        const firstUnsignedSignature: SignatureEntity | undefined = signatures.find((signature: SignatureEntity) => {
+          return signature.signed === false;
+        });
 
-        // If next signature is current user, then this form is a todo
-        if (nextSignature.signerPositionId === user.positionId) {
+        // If there is no unsigned signature, return false
+        if (!firstUnsignedSignature) {
+          return false;
+        }
+        
+        // If the first unsigned signature is the current user, return true
+        if (firstUnsignedSignature.signerPositionId === user.positionId) {
           return true;
         }
+
+        // Otherwise, return false
+        return false;
       },
     );
 


### PR DESCRIPTION
## Description/Problem

Closes [story](https://trello.com/c/qTAHzBFB/124-fix-todo-to-reflect-forms-that-are-ready-to-be-signed)

Previously, the todo section on the dashboard displayed the form as ready to sign for every user in the signature list. Users should only see forms they are ready to sign (they are first user in the signature list who has not signed the form yet).

## Solution

Changed the useForm hook to filter and sort forms to only return todo forms such that the user is first in the signature list.

## Dependencies

[ ] This PR adds new dependencies

## Testing

Created a form and tested with users who are first and not first.
  