### PR TITLE
Fix Directory Search

### DIFF
--- a/apps/web/src/components/createFormInstance/SignatureDropdown.tsx
+++ b/apps/web/src/components/createFormInstance/SignatureDropdown.tsx
@@ -36,16 +36,17 @@ export const SignatureDropdown = ({
     );
   };
 
-  const formatOptionLabel = ({ value, label }: Option) => (
-    <span>
-      <strong>
-        {getEmployeeName({
-          position: positions?.find((position) => position.id === value),
-        })}
-      </strong>
-      <span style={{ marginLeft: '8px', color: 'gray' }}>{label}</span>
-    </span>
-  );
+  const formatOptionLabel = ({ value, label }: Option) => {
+    const positionEntity = positions?.find((position) => position.id === value);
+    const employeeName = positionEntity?.name ?? '';
+
+    return (
+      <span>
+        <strong>{getEmployeeName({ position: positionEntity })}</strong>
+        <span style={{ marginLeft: '8px', color: 'gray' }}>{employeeName}</span>
+      </span>
+    );
+  };
 
   return (
     <Box w="100%">
@@ -56,9 +57,13 @@ export const SignatureDropdown = ({
         useBasicStyles
         selectedOptionStyle="check"
         options={positions?.map((position) => {
+          const employee = position.employees?.at(0);
+          const fullName =
+            employee?.firstName ?? '' + ' ' + employee?.lastName ?? '';
+          const fullLabel = fullName + ' ' + position.name;
           return {
             value: position.id,
-            label: position.name,
+            label: fullLabel,
           };
         })}
         placeholder={assigneePlaceholderWithIcon}


### PR DESCRIPTION
## Description/Problem

Closes [Fix Directory Search](https://www.notion.so/sandboxnu/0ff8d90722bf435db9475c07e2311a2b?v=f7473b246d1742e395395cf955037121&p=0d1a04364054475095b9b79829b92f0e&pm=s)

Previously for the drop downs on the create Form instance components, the search for the drop down only searched on the positions of all the potential assignees. This needed to be changed to include the employee name as well so you could search for both their name and position. 

## Solution

What did you change?

Updated the SignatureDropDown component to include the employeeName and position for the label to be searched upon

## Testing

Please describe how you tested this PR (manually and/or automatically)
Provide instructions so we can reproduce, and include screenshots of UI changes.

- Manual Tests?
Manual testing: try the search now in the select dropdown for the create form instance, and search with an assignee name, both name and position should now be supported

  