### PR TITLE
Add Nextauth Secret

### DIFF
--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -82,6 +82,7 @@ export const authOptions = {
       return session;
     },
   },
+  secret: process.env.NEXTAUTH_SECRET || 'next-auth-secret',
 };
 
 export default NextAuth(authOptions);


### PR DESCRIPTION
## Description/Problem

No NextAuth secret, which may be causing deployment to not be able to signin. 

## Solution

Add Nextauth secret.

## Dependencies

[ ] This PR adds new dependencies

## Testing

Manual tests.
  