### PR TITLE
167 bug adjust form image card and see all button width

### DIFF
--- a/apps/web/src/components/FormImageCard.tsx
+++ b/apps/web/src/components/FormImageCard.tsx
@@ -33,7 +33,7 @@ export const FormImageCard = ({
 
   return (
     <Box
-      width="246px"
+      width="272px"
       borderRadius="8px"
       backgroundColor="#FFFFFF"
       border="1px solid #D4D4D4"

--- a/apps/web/src/components/FormImageCard.tsx
+++ b/apps/web/src/components/FormImageCard.tsx
@@ -34,6 +34,7 @@ export const FormImageCard = ({
   return (
     <Box
       width="272px"
+      paddingBottom="10px"
       borderRadius="8px"
       backgroundColor="#FFFFFF"
       border="1px solid #D4D4D4"

--- a/apps/web/src/components/FormList.tsx
+++ b/apps/web/src/components/FormList.tsx
@@ -49,7 +49,7 @@ export const FormList = ({
     <>
       <Box padding={isDashboard ? '12px 30px 12px 0px' : '12px 30px 12px 30px'}>
         <Flex justifyContent="space-between" pb="20px">
-          <Flex alignItems="flex-end">
+          <Flex alignItems="center">
             <Heading
               as="h2"
               textColor="#363940"

--- a/apps/web/src/components/OverviewRow.tsx
+++ b/apps/web/src/components/OverviewRow.tsx
@@ -35,34 +35,41 @@ export const OverviewRow = ({
 
   return (
     <>
-      <Box w={rowWidth}>
-        <Flex justifyContent="space-between" alignItems="center">
-          <Flex alignItems="center">
-            <Heading as="h2" color="#32353B" fontSize="24px" fontWeight="600">
-              {title == 'To-do'
-                ? `You have ${formInstances.length} forms waiting for you.`
-                : title}
-            </Heading>
+      <Flex justifyContent="space-between">
+        <Flex alignItems="center">
+          <Heading as="h2" color="#32353B" fontSize="24px" fontWeight="600">
+            {title == 'To-do'
+              ? `You have ${formInstances.length} forms waiting for you.`
+              : title}
+          </Heading>
 
-            {title != 'To-do' && (
-              <Flex
-                marginLeft="13px"
-                backgroundColor={color}
-                height="18px"
-                width="32px"
-                borderRadius="12"
-                justifyContent="center"
-                alignItems="center"
-              >
-                <Text fontSize="14px" fontWeight="700" color="#756160">
-                  {formInstances.length}
-                </Text>
-              </Flex>
-            )}
-          </Flex>
+          {title != 'To-do' && (
+            <Flex
+              marginLeft="13px"
+              backgroundColor={color}
+              height="18px"
+              width="32px"
+              borderRadius="12"
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Text fontSize="14px" fontWeight="700" color="#756160">
+                {formInstances.length}
+              </Text>
+            </Flex>
+          )}
+        </Flex>
+        <Flex pr="30px">
           <ViewAll title={title} link={link} />
         </Flex>
-        <HStack spacing="16px" marginTop="20px">
+      </Flex>
+      <Flex>
+        <HStack
+          marginTop="20px"
+          justifyContent="space-between"
+          width="100vw"
+          pr="30px"
+        >
           {displayFormInstances.map(
             (formInstance: FormInstanceEntity, index: number) => {
               return title == 'To-do' ? (
@@ -82,7 +89,7 @@ export const OverviewRow = ({
             },
           )}
         </HStack>
-      </Box>
+      </Flex>
     </>
   );
 };

--- a/apps/web/src/components/OverviewRow.tsx
+++ b/apps/web/src/components/OverviewRow.tsx
@@ -1,7 +1,5 @@
 import { HStack, Flex, Box, Text, Heading } from '@chakra-ui/react';
 import { FormCard } from './FormCard';
-import { RightArrowIcon } from 'apps/web/src/static/icons';
-import Link from 'next/link';
 import { FormInstanceEntity } from '@web/client';
 import React from 'react';
 import { FormImageCard } from './FormImageCard';
@@ -20,13 +18,11 @@ export const OverviewRow = ({
   color,
   link,
   formInstances,
-  rowWidth,
 }: {
   title: string;
   color: string;
   link: string;
   formInstances: FormInstanceEntity[];
-  rowWidth: number;
 }) => {
   let displayFormInstances: FormInstanceEntity[] = formInstances.slice(
     0,

--- a/apps/web/src/components/OverviewRow.tsx
+++ b/apps/web/src/components/OverviewRow.tsx
@@ -48,7 +48,7 @@ export const OverviewRow = ({
               height="18px"
               width="32px"
               borderRadius="12"
-              justifyContent="center"
+              justifyItems="center"
               alignItems="center"
             >
               <Text fontSize="14px" fontWeight="700" color="#756160">
@@ -61,33 +61,32 @@ export const OverviewRow = ({
           <ViewAll title={title} link={link} />
         </Flex>
       </Flex>
-      <Flex>
-        <HStack
-          marginTop="20px"
-          justifyContent="space-between"
-          width="100vw"
-          pr="30px"
-        >
-          {displayFormInstances.map(
-            (formInstance: FormInstanceEntity, index: number) => {
-              return title == 'To-do' ? (
-                <FormImageCard
-                  key={index}
-                  formInstance={formInstance}
-                  link={'/form-instances/' + formInstance.id}
-                />
-              ) : (
-                <FormCard
-                  key={index}
-                  formName={formInstance.name}
-                  signatures={formInstance.signatures}
-                  link={'/form-instances/' + formInstance.id}
-                />
-              );
-            },
-          )}
-        </HStack>
-      </Flex>
+      <HStack
+        marginTop="20px"
+        flexDirection="row"
+        justifyContent="space-between"
+        wrap="wrap"
+        pr="30px"
+      >
+        {displayFormInstances.map(
+          (formInstance: FormInstanceEntity, index: number) => {
+            return title == 'To-do' ? (
+              <FormImageCard
+                key={index}
+                formInstance={formInstance}
+                link={'/form-instances/' + formInstance.id}
+              />
+            ) : (
+              <FormCard
+                key={index}
+                formName={formInstance.name}
+                signatures={formInstance.signatures}
+                link={'/form-instances/' + formInstance.id}
+              />
+            );
+          },
+        )}
+      </HStack>
     </>
   );
 };

--- a/apps/web/src/components/OverviewRow.tsx
+++ b/apps/web/src/components/OverviewRow.tsx
@@ -35,7 +35,9 @@ export const OverviewRow = ({
         <Flex alignItems="center">
           <Heading as="h2" color="#32353B" fontSize="24px" fontWeight="600">
             {title == 'To-do'
-              ? `You have ${formInstances.length} forms waiting for you.`
+              ? `You have ${formInstances.length} ${
+                  formInstances.length == 1 ? 'form' : 'forms'
+                } waiting for you.`
               : title}
           </Heading>
 

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -19,14 +19,6 @@ export default function Overview() {
 
   if (assignedFIError || createdFIError) return <Error />;
 
-  const rowWidth = Math.max(
-    260 * 1.5,
-    Math.min(
-      4,
-      Math.max(todoForms.length, pendingForms.length, completedForms.length),
-    ) * 260,
-  );
-
   return (
     <>
       <Box marginLeft="40px" height="100vh" marginTop="36px">
@@ -36,7 +28,6 @@ export default function Overview() {
             color="#FFDFDE"
             link="/todo"
             formInstances={todoForms}
-            rowWidth={rowWidth}
           />
         </Box>
         <FormList


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I got rid of the row width calculation, so instead the See All button and cards can go all the way to the end, with 30px of padding on the right.  The cards also wrap now as the window is resized.  I also changed the title for the card section to say "form" instead of "forms" if there's only one.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The spacing of the cards and the See All button were not up to date with the Figma files.

Closes [#167]

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I looked at the spacing of the elements and tried resizing the window to make sure they move between rows.

## Screenshots (if appropriate):
<img width="1512" alt="Screenshot 2024-10-20 at 10 22 34 PM" src="https://github.com/user-attachments/assets/5361aeb0-e509-4c79-bf6f-839e63dbbd65">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
