### PR TITLE
172 feature reconfigure form signing approving and category logic

### DIFF
--- a/apps/server/src/form-instances/form-instances.service.ts
+++ b/apps/server/src/form-instances/form-instances.service.ts
@@ -412,12 +412,8 @@ export class FormInstancesService {
     }
 
     const isOriginator = formInstance.originator.id === employeeId;
-    const isAdminInSameDepartment =
-      currUser.isAdmin &&
-      currUser.position.departmentId ===
-        formInstance.originator.position.departmentId;
 
-    if (!isOriginator && !isAdminInSameDepartment) {
+    if (!isOriginator) {
       throw new BadRequestException(
         FormInstanceErrorMessage.FORM_INSTANCE_INVALID_MARKED_COMPLETED,
       );

--- a/apps/web/src/components/FormImageCard.tsx
+++ b/apps/web/src/components/FormImageCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { useStorage } from '@web/hooks/useStorage';
 import { Document, Page, pdfjs } from 'react-pdf';
+import { isFullySigned } from '@web/utils/formInstanceUtils';
 
 /**
  * @param formName - the name of the form
@@ -28,12 +29,12 @@ export const FormImageCard = ({
     const d2 = new Date(date2);
     const diffInTime = d2.getTime() - d1.getTime();
     const diffInDays = Math.ceil(diffInTime / (1000 * 60 * 60 * 24));
-    return diffInDays == 0 ? 'today' : `${diffInDays} days ago`;
+    return diffInDays == 0 ? 'today' : `${diffInDays}d ago`;
   };
 
   return (
     <Box
-      width="246px"
+      width="272px"
       borderRadius="8px"
       backgroundColor="#FFFFFF"
       border="1px solid #D4D4D4"
@@ -89,7 +90,7 @@ export const FormImageCard = ({
             borderRadius="20px"
             padding="3px 12px"
           >
-            TO DO
+            {isFullySigned(formInstance) ? 'NEEDS APPROVAL' : 'TO DO'}
           </Text>
           <Text
             textAlign="center"

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -35,6 +35,7 @@ export const AuthProvider = ({ children }: any) => {
   // Reset the error state if we change page
   useEffect(() => {
     if (error) setError(undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.pathname]);
 
   // Check if there is a currently active session
@@ -68,6 +69,7 @@ export const AuthProvider = ({ children }: any) => {
           });
       })
       .finally(() => setLoadingInitial(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Flags the component loading state and posts the login
@@ -120,6 +122,7 @@ export const AuthProvider = ({ children }: any) => {
       login,
       logout,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [user, loading, error],
   );
 

--- a/apps/web/src/utils/formInstanceUtils.ts
+++ b/apps/web/src/utils/formInstanceUtils.ts
@@ -1,0 +1,43 @@
+import { FormInstanceEntity, SignatureEntity } from '@web/client';
+
+/**
+ * Determines if a form instance is fully signed
+ *
+ * @param formInstance the form instance to check
+ * @returns true if the form instance is fully signed, false otherwise
+ */
+export const isFullySigned = (formInstance: FormInstanceEntity) => {
+  const signatures: SignatureEntity[] = formInstance.signatures;
+
+  const unsignedSignatures: SignatureEntity[] = signatures.filter(
+    (signature: SignatureEntity) => {
+      return !signature.signed;
+    },
+  );
+
+  return unsignedSignatures.length === 0;
+};
+
+/**
+ * Finds the next signer in the signature chain of a form instance
+ *
+ * @param formInstance  the form instance to check
+ * @returns the next signer in the signature chain
+ */
+export const nextSigner = (formInstance: FormInstanceEntity) => {
+  const signatures: SignatureEntity[] = formInstance.signatures;
+
+  // Sort signatures by order
+  signatures.sort((a: SignatureEntity, b: SignatureEntity) => {
+    return a.order - b.order;
+  });
+
+  // Find the first signature that doesn't have a signature
+  const firstUnsignedSignature: SignatureEntity | undefined = signatures.find(
+    (signature: SignatureEntity) => {
+      return signature.signed === false;
+    },
+  );
+
+  return firstUnsignedSignature;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Update useForm hook to set todo, pending, and completed forms correctly: 

Todo
- Your turn to sign the form
- You are the originator and the form is ready to be approved

Pending
- Originator: forms that are still in progress of being signed
- Member of chain: form that are still in the progress of being signed or awaiting approval

Completed
- Approved forms that everyone can see in the chain

Update frontend to reflect needs approval status.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Reduce confusion of those categories and make it consistent with what client wants.

Closes [#172]

## How has this been tested?

Created, signed, and approved forms with various edge cases.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional Context

This change assumes that we can only assign a user to sign a form once.
