### PR TITLE
[BUG] Move all login logic into authcontext so msal instance is declared once

### DIFF
--- a/apps/web/src/components/AzureSignin.tsx
+++ b/apps/web/src/components/AzureSignin.tsx
@@ -8,26 +8,10 @@ import { useAuth } from '@web/hooks/useAuth';
  * @returns a button that allows users to sign in with Azure
  */
 export const AzureSignin: React.FC = () => {
-  const { instance } = useMsal();
-  const { login } = useAuth();
-
-  const handleLogin = () => {
-    try {
-      instance
-        .loginPopup(loginRequest)
-        .then((response) => {
-          login(response.account.username, 'password');
-        })
-        .catch((error) => {
-          console.error(error);
-        });
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  const { azureLogin } = useAuth();
 
   return (
-    <Button color="#FFF" background="#2596be" onClick={handleLogin}>
+    <Button color="#FFF" background="#2596be" onClick={azureLogin}>
       Sign in with Azure
     </Button>
   );

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -17,7 +17,7 @@ export const AuthContext = createContext<AuthContextType>(
 
 export const AuthProvider = ({ children }: any) => {
   const router = useRouter();
-  const { instance: msalInstance, accounts: msalAccounts } = useMsal();
+  const { instance } = useMsal();
   const [user, setUser] = useState<User>();
   const [error, setError] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -117,12 +117,23 @@ export const AuthProvider = ({ children }: any) => {
       .finally(() => setLoading(false));
   };
 
+  const azureLogin = () => {
+    instance
+      .loginPopup(loginRequest)
+      .then((response) => {
+        login(response.account.username, 'password');
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  };
+
   // Request the profile data from the Microsoft Graph API
   const requestProfileData = async () => {
     try {
-      const response = await msalInstance.acquireTokenSilent({
+      const response = await instance.acquireTokenSilent({
         ...loginRequest,
-        account: msalAccounts[0],
+        account: instance.getAllAccounts()[0],
       });
       const profileData = await callMsGraph(response.accessToken);
       return profileData;
@@ -180,6 +191,7 @@ export const AuthProvider = ({ children }: any) => {
       loading,
       error,
       login,
+      azureLogin,
       logout,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/src/context/types.ts
+++ b/apps/web/src/context/types.ts
@@ -1,3 +1,5 @@
+import { IPublicClientApplication } from '@azure/msal-browser';
+
 // for storage in context
 export type User = {
   id: string;
@@ -22,5 +24,6 @@ export interface AuthContextType {
   loading: boolean;
   error?: any;
   login: (email: string, password: string) => void;
+  azureLogin: () => void;
   logout: () => void;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes crash when registering with an account that doesn't exist.

## Motivation and Context

Register caused a crash due to accounts not being set within msal instance.

Closes [#Did not create a ticket for this oops]

## How has this been tested?

I reset the database 5 times and logged in with azure, no crashes observed.
Before, we would crash when trying to register the first time with a new account.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
