### PR TITLE
Fix form blur, allow users who are in a position or department to see forms they are assigned

### DIFF
--- a/apps/server/src/form-instances/form-instances.service.ts
+++ b/apps/server/src/form-instances/form-instances.service.ts
@@ -392,13 +392,18 @@ export class FormInstancesService {
     } else {
       // Notify next user that form is ready to sign
       const nextUserToSignId = formInstance.signatures[signatureIndex + 1];
-      const emailBod2y: string = `Hi ${formInstance.originator.firstName}, you have a form ready for your signature: ${formInstance.name}.`;
-      const emailSubject2: string = `Form ${formInstance.name} Ready To Sign`;
-      this.postmarkService.sendEmail(
-        nextUserToSignId.assignedUser!.email,
-        emailSubject2,
-        emailBod2y,
-      );
+
+      if (nextUserToSignId.signerType === SignerType.USER) {
+        const emailBod2y: string = `Hi ${formInstance.originator.firstName}, you have a form ready for your signature: ${formInstance.name}.`;
+        const emailSubject2: string = `Form ${formInstance.name} Ready To Sign`;
+        this.postmarkService.sendEmail(
+          nextUserToSignId.assignedUser!.email,
+          emailSubject2,
+          emailBod2y,
+        );
+      } else {
+        // TODO: Implement sending email to department or position
+      }
 
       // Notify originator that form was signed
       const emailBody: string = `Hi ${formInstance.originator.firstName}, your form ${formInstance.name} has been signed by user: ${employee.firstName} ${employee.lastName}.`;

--- a/apps/web/src/components/FormImageCard.tsx
+++ b/apps/web/src/components/FormImageCard.tsx
@@ -55,6 +55,10 @@ export const FormImageCard = ({
           overflow="hidden"
           height="full"
           filter="blur(2px)"
+          transition="filter 0.3s ease" // Smooth transition for the blur effect
+          _hover={{
+            filter: 'blur(0px)',
+          }}
         >
           <Document file={formURL}>
             <Page

--- a/apps/web/src/components/FormInstance.tsx
+++ b/apps/web/src/components/FormInstance.tsx
@@ -23,7 +23,10 @@ import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '@web/pages/_app';
 import { useAuth } from '@web/hooks/useAuth';
 import { useStorage } from '@web/hooks/useStorage';
-import { getNameFromSignature } from '@web/utils/formInstanceUtils';
+import {
+  getNameFromSignature,
+  signerIsUser,
+} from '@web/utils/formInstanceUtils';
 
 /**
  * @param formInstance - the form instance
@@ -73,7 +76,7 @@ const FormInstance = ({
   const _nextSignature = formInstance.signatures
     .sort((a, b) => a.order - b.order)
     .find((v) => v.signed === false);
-  const _userCanSign = _nextSignature?.assignedUserId === user?.id;
+  const _userCanSign = signerIsUser(_nextSignature!, user!);
 
   /**
    * Update the form instance with the next signature

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -159,7 +159,7 @@ export const NavBar = ({
             Create
           </MenuButton>
           <MenuButton padding="8px 22px 8px 16px"></MenuButton>
-          <MenuList minW="0px" w={'124px'} p="5px">
+          <MenuList>
             <MenuItem rounded="8px" onClick={onOpenCreateFormInstance}>
               Form
             </MenuItem>

--- a/apps/web/src/context/types.ts
+++ b/apps/web/src/context/types.ts
@@ -4,6 +4,7 @@ import { IPublicClientApplication } from '@azure/msal-browser';
 export type User = {
   id: string;
   positionId: string;
+  departmentId: string;
   email: string;
   firstName: string;
   lastName: string;

--- a/apps/web/src/hooks/useForm.ts
+++ b/apps/web/src/hooks/useForm.ts
@@ -6,7 +6,11 @@ import {
 } from './../../../web/src/client';
 import { useAuth } from './useAuth';
 import { useQuery } from '@tanstack/react-query';
-import { isFullySigned, nextSigner } from '@web/utils/formInstanceUtils';
+import {
+  isFullySigned,
+  nextSigner,
+  signerIsUser,
+} from '@web/utils/formInstanceUtils';
 
 /**
  * @returns an object containing the todo, pending, and completed forms
@@ -75,7 +79,7 @@ export const useForm = () => {
     // Forms assigned to current user that they still need to sign
     const todoForms: FormInstanceEntity[] = assignedFIData.filter(
       (formInstance: FormInstanceEntity) => {
-        return nextSigner(formInstance)?.assignedUserId === user?.id;
+        return signerIsUser(nextSigner(formInstance)!, user);
       },
     );
 
@@ -95,7 +99,7 @@ export const useForm = () => {
       (formInstance: FormInstanceEntity) => {
         return (
           !isFullySigned(formInstance) &&
-          nextSigner(formInstance)?.assignedUserId !== user?.id
+          !signerIsUser(nextSigner(formInstance)!, user)
         );
       },
     );

--- a/apps/web/src/utils/formInstanceUtils.ts
+++ b/apps/web/src/utils/formInstanceUtils.ts
@@ -1,4 +1,9 @@
-import { FormInstanceEntity, SignatureEntity } from '@web/client';
+import {
+  FormInstanceEntity,
+  PositionsService,
+  SignatureEntity,
+} from '@web/client';
+import { User } from '@web/context/types';
 
 /**
  * Determines if a form instance is fully signed
@@ -82,4 +87,24 @@ export const nextSigner = (formInstance: FormInstanceEntity) => {
   );
 
   return firstUnsignedSignature;
+};
+
+/**
+ * Determines if a signature's next signer is the current user
+ *
+ * @param signature the signature to check
+ * @param user the current user
+ * @returns true if the next signer is the current user, false otherwise
+ */
+export const signerIsUser = (signature: SignatureEntity, user: User) => {
+  if (!signature) return false;
+
+  const signerType = signature.signerType as any;
+  return (
+    (signerType === 'USER' && signature.assignedUserId === user?.id) ||
+    (signerType === 'POSITION' &&
+      signature.signerPositionId === user?.positionId) ||
+    (signerType === 'DEPARTMENT' &&
+      user?.departmentId === signature.signerDepartmentId)
+  );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix form hover blur
- Users can see forms assigned to their departments and positions, and can sign those forms
- The email notification system is broken so temp fix to not send emails to non users
- Also temporarily added dept id to user type in AuthContext, we can probably do this in the backend later

## Motivation and Context

- This was broken, so users who were assigned forms couldn't see it

Closes [#didnt make one rip]

## How has this been tested?

SIgning forms

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ].. My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
