### PR TITLE
196 handle email notifications for user list, fix some avatars when a user signs

### DIFF
--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -466,6 +466,19 @@ async function main() {
           signerType: 'USER',
           assignedUserId: KAI_ZHENG_UUID,
         },
+        {
+          id: 'f9f9a4a4-4c0d-4f7e-8c2e-6b1e9b9b0e3b',
+          order: 1,
+          signerType: 'USER_LIST',
+          assignedUserList: {
+            connect: [
+              { id: IRIS_ZHANG_UUID },
+              { id: KAI_ZHENG_UUID },
+              { id: ANGELA_WEIGL_UUID },
+              { id: ANSHUL_SHIRUDE_UUID },
+            ],
+          },
+        },
       ],
     },
     {

--- a/apps/server/src/form-instances/form-instances.service.ts
+++ b/apps/server/src/form-instances/form-instances.service.ts
@@ -97,7 +97,7 @@ export class FormInstancesService {
     // Notify originator of email creation
     this.postmarkService.sendFormCreatedEmail(
       newFormInstance.originator.email,
-      newFormInstance.originator.firstName,
+      `${newFormInstance.originator.firstName} ${newFormInstance.originator.lastName}`,
       newFormInstance.name,
     );
 
@@ -414,7 +414,7 @@ export class FormInstancesService {
       // Notify originator that form is ready for approval
       this.postmarkService.sendReadyForApprovalEmail(
         formInstance.originator.email,
-        formInstance.originator.firstName,
+        `${formInstance.originator.firstName} ${formInstance.originator.lastName}`,
         formInstance.name,
       );
     } else {
@@ -437,14 +437,22 @@ export class FormInstancesService {
           nextUserToSignId.signerDepartmentId!,
           formInstance.name,
         );
+      } else if (nextUserToSignId.signerType === SignerType.USER_LIST) {
+        this.postmarkService.sendReadyForSignatureToUserListEmail(
+          nextUserToSignId.assignedUserList!,
+          formInstance.name,
+        );
       }
 
       // Notify originator that form was signed
       this.postmarkService.sendSignedEmail(
         formInstance.originator.email,
-        formInstance.originator.firstName,
-        employee.firstName,
-        employee.lastName,
+        `${
+          formInstance.originator.firstName +
+          ' ' +
+          formInstance.originator.lastName
+        }`,
+        `${employee.firstName} ${employee.lastName}`,
         formInstance.name,
       );
     }

--- a/apps/server/src/postmark/postmark.service.ts
+++ b/apps/server/src/postmark/postmark.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ServerClient } from 'postmark';
+import { Employee } from '@prisma/client';
 
 @Injectable()
 export class PostmarkService {
@@ -121,6 +122,24 @@ export class PostmarkService {
   }
 
   /**
+   * Send an email to a list of users that a form is ready for their signature
+   * @param to the list of email addresses to send to
+   * @param formName
+   */
+  async sendReadyForSignatureToUserListEmail(
+    userList: Employee[],
+    formName: string,
+  ) {
+    userList.forEach(async (user) => {
+      await this.sendReadyForSignatureToUserEmail(
+        user.email,
+        `${user.firstName} ${user.lastName}`,
+        formName,
+      );
+    });
+  }
+
+  /**
    * Send an email to the originator that a form has been signed
    * @param to email address to send to
    * @param originatorName the name of the originator
@@ -131,12 +150,11 @@ export class PostmarkService {
   async sendSignedEmail(
     to: string,
     originatorName: string,
-    signerFirstName: string,
-    signerLastName: string,
+    signerName: string,
     formName: string,
   ) {
-    const subject: string = `Form ${formName} Signed By ${signerFirstName} ${signerLastName}`;
-    const body: string = `Hi ${originatorName}, your form ${formName} has been signed by user: ${signerFirstName} ${signerLastName}.`;
+    const subject: string = `Form ${formName} Signed By ${signerName}`;
+    const body: string = `Hi ${originatorName}, your form ${formName} has been signed by user: ${signerName}.`;
 
     await this.sendEmail(to, subject, body);
   }

--- a/apps/web/src/components/AvatarMap.tsx
+++ b/apps/web/src/components/AvatarMap.tsx
@@ -14,7 +14,7 @@ const AssigneeMap: React.FC<AvatarMapProps> = ({ assignees }) => {
     signerType: string,
     isSigned: boolean,
   ) => {
-    if (isSigned) {
+    if (isSigned || signerType === 'USER') {
       return title;
     } else if (signerType === 'DEPARTMENT') {
       return 'D';

--- a/apps/web/src/components/AvatarMap.tsx
+++ b/apps/web/src/components/AvatarMap.tsx
@@ -9,16 +9,20 @@ import { AvatarMapProps } from './types';
 const AssigneeMap: React.FC<AvatarMapProps> = ({ assignees }) => {
   let previousSigned = true;
 
-  const getInitialsFromTitle = (title: string, signerType: string) => {
-    if (signerType === 'DEPARTMENT') {
+  const getInitialsFromTitle = (
+    title: string,
+    signerType: string,
+    isSigned: boolean,
+  ) => {
+    if (isSigned) {
+      return title;
+    } else if (signerType === 'DEPARTMENT') {
       return 'D';
     } else if (signerType === 'POSITION') {
       return 'P';
     } else if (signerType === 'USER_LIST') {
       return 'U';
     }
-
-    return title;
   };
 
   return (
@@ -31,7 +35,11 @@ const AssigneeMap: React.FC<AvatarMapProps> = ({ assignees }) => {
           <Flex key={index} align="center" my={4} position="relative">
             <Flex align="center" flex="1" zIndex={1}>
               <Avatar
-                name={getInitialsFromTitle(assignee.title, assignee.signerType)}
+                name={getInitialsFromTitle(
+                  assignee.title,
+                  assignee.signerType,
+                  assignee.signed,
+                )}
                 size="sm"
                 color="black"
                 bg={

--- a/apps/web/src/components/FormInstance.tsx
+++ b/apps/web/src/components/FormInstance.tsx
@@ -289,7 +289,7 @@ const FormInstance = ({
               <AssigneeMap
                 assignees={formInstance.signatures.map((signature) => ({
                   signed: signature.signed,
-                  title: getNameFromSignature(signature, user!),
+                  title: getNameFromSignature(signature),
                   signerType: signature.signerType as any,
                   updatedAt: signature.updatedAt,
                 }))}

--- a/apps/web/src/utils/formInstanceUtils.ts
+++ b/apps/web/src/utils/formInstanceUtils.ts
@@ -24,12 +24,10 @@ export const isFullySigned = (formInstance: FormInstanceEntity) => {
  * @param signature the signature to check
  * @returns the name of the signer
  */
-export const getNameFromSignature = (
-  signature: SignatureEntity,
-  user: User,
-) => {
+export const getNameFromSignature = (signature: SignatureEntity) => {
   const signerType = signature.signerType as any;
-  if (signerType === 'USER') {
+
+  if (signature.signed || signerType === 'USER') {
     return (
       signature.assignedUser?.firstName! +
       ' ' +
@@ -66,7 +64,8 @@ export const getNameFromSignature = (
  */
 export const getInitialsFromSignature = (signature: SignatureEntity) => {
   const signerType = signature.signerType as any;
-  if (signerType === 'USER') {
+
+  if (signature.signed || signerType === 'USER') {
     return (
       signature.assignedUser?.firstName! +
       ' ' +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Send email to all emails in user list when `USER_LIST` signer type is next.
- When a signature is signed, the avatar now shows the initials of the signer

## Motivation and Context

- Email notifications for `USER_LIST`
- Avatar for signed signatures

Closes [#196 ]

## How has this been tested?

- New seed file form instance `Staffing Requisition Form Instance` with `USER_LIST` as second signature, signing as the first user results in email to all users in the list
- Signing as a position, department, or list changes the avatar to initials

## Screenshots (if appropriate):
Before signing:
![image](https://github.com/user-attachments/assets/2ac826f3-b7bf-4571-95e4-6c0146f93614)

After signing:
![image](https://github.com/user-attachments/assets/7ea4ce81-085c-48a3-9c6e-057be37c36f4)
![image](https://github.com/user-attachments/assets/5a46c3a1-4de0-4263-9609-f281c167a7b8)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
