### PR TITLE
fix docker compose for dev backend by adding env variables

### DIFF
--- a/apps/server/docker-compose.yml
+++ b/apps/server/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       DATABASE_URL: postgres://user:pass@postgres:5432/db
       NODE_ENV: development
       PORT: 8080
+      JWT_SECRET: process.env.JWT_SECRET
+      JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET
+      POSTMARK_SERVER_KEY: process.env.POSTMARK_SERVER_KEY
     ports:
       - '8080:8080'
     command: node dist/src/main.js


### PR DESCRIPTION
The mfa-backend container was broken because secrets were not defined properly. Now it actually starts instead of restarting forever.