### PR TITLE
Fix issue with auth

### DIFF
--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -70,7 +70,6 @@ export class AuthService {
       positionId: user.positionId,
       departmentId: user.position?.departmentId,
       scope: user.scope,
-      signatureLink: user.signatureLink,
     };
 
     const [accessToken, refreshToken] = await Promise.all([


### PR DESCRIPTION
The issue was that the data encoding for the signature image is too big and is passed into the jwt encoding. This makes the jwt too big (> 4096 characters), which exceeds the browser limit and doesn't allow cookies to be set.

Fixed issue by removing signature link from the login controller so we dont' set the signature link in the jwt. Because of this, we have to make a fetchCurrentUser request to set the link in context.

5 big booms.

Big thanks to rishi for helping me.

Elvin where tf were you!!!