### PR TITLE
only allow admins and contributors to create templates

### DIFF
--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -120,6 +120,8 @@ export const NavBar = ({
   const router = useRouter();
   const { user } = useAuth();
   const isAdmin = user?.scope == Scope.ADMIN;
+  const isAdminOrContributor =
+    user?.scope == Scope.ADMIN || user?.scope == Scope.CONTRIBUTOR;
   const [isCreateDropdownOpen, setIsCreateDropdownOpen] = useState(false);
 
   return (
@@ -171,7 +173,7 @@ export const NavBar = ({
             </Button>
           </MenuTrigger>
           <MenuContent zIndex="1100" py="6px">
-            {isAdmin && (
+            {isAdminOrContributor && (
               <MenuItem
                 onClick={() => router.push('create-template/upload')}
                 value="template"

--- a/apps/web/src/components/createFormInstance/FormTemplateGrid.tsx
+++ b/apps/web/src/components/createFormInstance/FormTemplateGrid.tsx
@@ -11,7 +11,7 @@ export const TemplateSelectGrid = ({
 }: {
   formTemplates: FormTemplateEntity[];
   allowCreate: boolean;
-  handleSelectTemplate: any;
+  handleSelectTemplate: (template: FormTemplateEntity) => void;
   selectedFormTemplate: FormTemplateEntity | null;
 }) => {
   return (
@@ -28,7 +28,7 @@ export const TemplateSelectGrid = ({
             key={template.id}
             flexDirection="column"
             onClick={() => {
-              handleSelectTemplate(template.id);
+              handleSelectTemplate(template);
             }}
             cursor="pointer"
             width="200px"

--- a/apps/web/src/components/createFormInstance/FormTemplateGrid.tsx
+++ b/apps/web/src/components/createFormInstance/FormTemplateGrid.tsx
@@ -1,26 +1,18 @@
 import { Grid, Box, Flex, Text, Button } from '@chakra-ui/react';
-import { useQuery } from '@tanstack/react-query';
 import { PDFDocument } from '../PDFDocument';
 import router from 'next/router';
 import { FormTemplateEntity } from '@web/client';
-import { useEffect, useState } from 'react';
-import { queryClient } from '@web/pages/_app';
-import { formTemplatesControllerFindAllQueryKey } from '@web/client/@tanstack/react-query.gen';
 
 export const TemplateSelectGrid = ({
   formTemplates,
   allowCreate,
   handleSelectTemplate,
   selectedFormTemplate,
-  refresh,
-  setRefresh,
 }: {
   formTemplates: FormTemplateEntity[];
   allowCreate: boolean;
   handleSelectTemplate: any;
   selectedFormTemplate: FormTemplateEntity | null;
-  refresh?: boolean;
-  setRefresh?: any;
 }) => {
   return (
     <Grid

--- a/apps/web/src/pages/create-instance/select-template.tsx
+++ b/apps/web/src/pages/create-instance/select-template.tsx
@@ -6,33 +6,20 @@ import isAuth from '@web/components/isAuth';
 import { useCreateFormInstance } from '@web/context/CreateFormInstanceContext';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@web/hooks/useAuth';
+import { formTemplatesControllerFindAllOptions } from '@web/client/@tanstack/react-query.gen';
 
 function SelectTemplate() {
   const { user } = useAuth();
-  const { formTemplate, formInstanceUseId } = useCreateFormInstance();
-  const { setFormTemplate, setFormInstanceName } = useCreateFormInstance();
+  const {
+    formTemplate,
+    formInstanceUseId,
+    setFormTemplate,
+    setFormInstanceName,
+  } = useCreateFormInstance();
 
-  const handleSelectTemplate = async (id: string) => {
-    try {
-      const response = await fetch(`/api/form-templates/${id}`);
-      if (!response.ok) throw new Error('Failed to find form template');
-
-      const template: FormTemplateEntity = await response.json();
-      setFormTemplate(template);
-      setFormInstanceName(template.name);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const { data: formTemplates } = useQuery<FormTemplateEntity[]>({
-    queryKey: ['api', 'form-templates'],
-    queryFn: async () => {
-      const response = await fetch('/api/form-templates');
-      if (!response.ok) throw new Error('Failed to get form templates');
-      return response.json();
-    },
-  });
+  const { data: formTemplates } = useQuery(
+    formTemplatesControllerFindAllOptions(),
+  );
 
   return (
     <FormLayout
@@ -52,7 +39,10 @@ function SelectTemplate() {
           allowCreate={
             user?.scope === Scope.ADMIN || user?.scope === Scope.CONTRIBUTOR
           }
-          handleSelectTemplate={handleSelectTemplate}
+          handleSelectTemplate={(template: FormTemplateEntity) => {
+            setFormTemplate(template);
+            setFormInstanceName(template.name);
+          }}
           selectedFormTemplate={formTemplate}
         />
       }

--- a/apps/web/src/pages/create-instance/select-template.tsx
+++ b/apps/web/src/pages/create-instance/select-template.tsx
@@ -1,14 +1,14 @@
-import { Scope } from '@web/client/types.gen';
 import { FormLayout } from '@web/components/createForm/FormLayout';
 import { FormInteractionType } from '@web/components/createForm/types';
-import { FormTemplateEntity } from '@web/client/types.gen';
+import { FormTemplateEntity, Scope } from '@web/client/types.gen';
 import { TemplateSelectGrid } from '@web/components/createFormInstance/FormTemplateGrid';
 import isAuth from '@web/components/isAuth';
 import { useCreateFormInstance } from '@web/context/CreateFormInstanceContext';
-import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@web/hooks/useAuth';
 
 function SelectTemplate() {
+  const { user } = useAuth();
   const { formTemplate, formInstanceUseId } = useCreateFormInstance();
   const { setFormTemplate, setFormInstanceName } = useCreateFormInstance();
 
@@ -49,7 +49,9 @@ function SelectTemplate() {
       boxContent={
         <TemplateSelectGrid
           formTemplates={formTemplates!!}
-          allowCreate={true}
+          allowCreate={
+            user?.scope === Scope.ADMIN || user?.scope === Scope.CONTRIBUTOR
+          }
           handleSelectTemplate={handleSelectTemplate}
           selectedFormTemplate={formTemplate}
         />

--- a/apps/web/src/pages/template-directory.tsx
+++ b/apps/web/src/pages/template-directory.tsx
@@ -12,7 +12,6 @@ import {
   formTemplatesControllerFindAllOptions,
   formTemplatesControllerFindAllQueryKey,
   formTemplatesControllerUpdateMutation,
-  formTemplatesControllerFindOneOptions,
 } from '@web/client/@tanstack/react-query.gen';
 import { SearchAndSort } from '@web/components/SearchAndSort';
 import { TemplateSelectGrid } from '@web/components/createFormInstance/FormTemplateGrid';
@@ -68,20 +67,6 @@ function TemplateDirectory() {
     formTemplatesControllerFindAllOptions(),
   );
 
-  const findOneTemplateMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const response = await queryClient.fetchQuery(
-        formTemplatesControllerFindOneOptions({
-          path: { id },
-        }),
-      );
-      return response;
-    },
-    onSuccess: (data) => {
-      setFormTemplate(data);
-    },
-  });
-
   useEffect(() => {
     if (!formTemplates) return;
     setSortedFormTemplates(
@@ -96,16 +81,6 @@ function TemplateDirectory() {
         .sort((a, b) => a.levenshteinDistance - b.levenshteinDistance),
     );
   }, [searchQuery, formTemplates]);
-
-  /**
-   * Sets the clicked form template to be chosen, allowing the user to select other
-   * features like editing and deleting for this form.  Note this does NOT prefill
-   * the useCreateFormTemplate data.
-   * @param id the id of the form template selected on screen
-   */
-  const handleSelectTemplate = async (id: string) => {
-    await findOneTemplateMutation.mutateAsync(id);
-  };
 
   const disableFormTemplateMutation = useMutation({
     ...formTemplatesControllerUpdateMutation(),
@@ -311,7 +286,9 @@ function TemplateDirectory() {
         <TemplateSelectGrid
           formTemplates={sortedFormTemplates!!}
           allowCreate={false}
-          handleSelectTemplate={handleSelectTemplate}
+          handleSelectTemplate={(template: FormTemplateEntity) =>
+            setFormTemplate(template)
+          }
           selectedFormTemplate={formTemplate}
         />
 

--- a/apps/web/src/pages/template-directory.tsx
+++ b/apps/web/src/pages/template-directory.tsx
@@ -60,8 +60,6 @@ function TemplateDirectory() {
   );
   // isOpen for the 'are you sure you want to delete' modal
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  // refresh form select template on change
-  const [refresh, setRefresh] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortedFormTemplates, setSortedFormTemplates] = useState<
     FormTemplateEntity[]
@@ -143,7 +141,6 @@ function TemplateDirectory() {
         throw e;
       });
 
-    setRefresh(!refresh);
     setIsOpen(false);
     setFormTemplate(null);
   };
@@ -316,8 +313,6 @@ function TemplateDirectory() {
           allowCreate={false}
           handleSelectTemplate={handleSelectTemplate}
           selectedFormTemplate={formTemplate}
-          refresh={refresh}
-          setRefresh={setRefresh}
         />
 
         <Flex


### PR DESCRIPTION
Only contributors and admins should be able to create a form template in the select form template page in create-instance pages

as an admin or contributor:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/1592d9c6-04eb-41bd-90e6-5bf097b895ff" />

as a user:
<img width="1326" alt="image" src="https://github.com/user-attachments/assets/a0992a2d-150d-4138-b649-5c9b848dbf65" />


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes [#<!--Insert issue # here-->]

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
