### PR TITLE
Reduce fetching in sign form instance context

### DIFF
--- a/apps/web/src/components/SignFormInstancePreview.tsx
+++ b/apps/web/src/components/SignFormInstancePreview.tsx
@@ -40,14 +40,14 @@ export const SignFormInstancePreview = ({
   const completeFormInstanceMutation = useMutation({
     ...formInstancesControllerCompleteFormInstanceMutation(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey: formInstancesControllerFindAllQueryKey(),
       });
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey:
           formInstancesControllerFindAllAssignedToCurrentEmployeeQueryKey(),
       });
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey:
           formInstancesControllerFindAllCreatedByCurrentEmployeeQueryKey(),
       });

--- a/apps/web/src/context/SignFormInstanceContext.tsx
+++ b/apps/web/src/context/SignFormInstanceContext.tsx
@@ -42,11 +42,12 @@ export const SignFormInstanceContextProvider = ({
       return failureCount < 3; // Retry up to 3 times for other errors
     },
   });
-  const [signFormInstanceLoading, setSignFormInstanceLoading] = useState(false);
   const [fields, setFields] = useState<FormField[][]>([]);
   const [groupNumber, setGroupNumber] = useState<number>(0);
   const [modifiedPdfLink, setModifiedPdfLink] = useState('');
   const [originalPdfLink, setOriginalPdfLink] = useState('');
+  const [originalPdf, setOriginalPdf] = useState<ArrayBuffer | null>(null);
+  const [modifiedPdf, setModifiedPdf] = useState<ArrayBuffer | null>(null);
   const [assignedGroupId, setAssignedGroupId] = useState<string>();
   const router = useRouter();
   const signFormInstanceMutation = useMutation({
@@ -65,6 +66,27 @@ export const SignFormInstanceContextProvider = ({
       });
     },
   });
+
+  // Fetch PDF data when links change
+  useEffect(() => {
+    const fetchPdfs = async () => {
+      if (originalPdfLink) {
+        const origPdf = await fetch(originalPdfLink).then((res) =>
+          res.arrayBuffer(),
+        );
+        setOriginalPdf(origPdf);
+      }
+      if (modifiedPdfLink) {
+        const modPdf = await fetch(modifiedPdfLink).then((res) =>
+          res.arrayBuffer(),
+        );
+        setModifiedPdf(modPdf);
+      }
+    };
+
+    fetchPdfs();
+  }, [originalPdfLink, modifiedPdfLink]);
+
   useEffect(() => {
     if (!formInstance || formInstanceError) return;
 
@@ -131,7 +153,6 @@ export const SignFormInstanceContextProvider = ({
     }
     const pdfLink = currentFormDocLink ?? formInstance.formDocLink;
     setOriginalPdfLink(pdfLink);
-    setModifiedPdfLink(pdfLink);
   }, [
     formInstance,
     formInstanceError,
@@ -261,9 +282,7 @@ export const SignFormInstanceContextProvider = ({
     submitLink: string,
     isReviewPage: boolean,
   ) => {
-    const existingPdfBytes = !isReviewPage
-      ? await fetch(originalPdfLink).then((res) => res.arrayBuffer())
-      : await fetch(modifiedPdfLink).then((res) => res.arrayBuffer());
+    const existingPdfBytes = !isReviewPage ? originalPdf : modifiedPdf;
 
     if (existingPdfBytes) {
       const pdfDoc = await PDFDocument.load(existingPdfBytes);
@@ -287,7 +306,7 @@ export const SignFormInstanceContextProvider = ({
         groupNumber,
         nextSignFormPage,
         updateField,
-        signFormInstanceLoading,
+        signFormInstanceLoading: isLoading,
       }}
     >
       {children}

--- a/apps/web/src/context/SignFormInstanceContext.tsx
+++ b/apps/web/src/context/SignFormInstanceContext.tsx
@@ -53,14 +53,14 @@ export const SignFormInstanceContextProvider = ({
   const signFormInstanceMutation = useMutation({
     ...formInstancesControllerSignFormInstanceMutation(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey: formInstancesControllerFindAllQueryKey(),
       });
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey:
           formInstancesControllerFindAllAssignedToCurrentEmployeeQueryKey(),
       });
-      await queryClient.invalidateQueries({
+      queryClient.invalidateQueries({
         queryKey:
           formInstancesControllerFindAllCreatedByCurrentEmployeeQueryKey(),
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We had excessive fetching in the form instance context whenever we clicked `Save and Continue`

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes [#<!--Insert issue # here-->]

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
