### PR TITLE
Deselect when focus switched off form field

### DIFF
--- a/apps/web/src/components/createFormTemplate/createFormTemplateEditor/CheckBox.tsx
+++ b/apps/web/src/components/createFormTemplate/createFormTemplateEditor/CheckBox.tsx
@@ -30,6 +30,7 @@ export default function Checkbox({
       position={{ x: currentPosition.x, y: currentPosition.y }}
       size={{ height: currentPosition.height, width: currentPosition.width }}
       border={selected ? `1px solid blue` : ''}
+      className="field-box"
       enableResizing={{
         bottom: false,
         bottomLeft: false,

--- a/apps/web/src/components/createFormTemplate/createFormTemplateEditor/FormEditor.tsx
+++ b/apps/web/src/components/createFormTemplate/createFormTemplateEditor/FormEditor.tsx
@@ -62,8 +62,16 @@ export const FormEditor = ({
   const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [groupNum, setGroupNum] = useState(fieldGroups.size);
   const [selectedField, setSelectedField] = useState<string | null>();
-  const [highlightedField, setHighlightedField] = useState<string>();
   const [lastClickTime, setLastClickTime] = useState(0);
+
+  // Handle clicks on the document to clear selected field when clicking outside
+  const handleDocumentClick = (event: React.MouseEvent) => {
+    // If the click originated from a field component, it will be handled by that component
+    // Otherwise, clear the selected field
+    if ((event.target as HTMLElement).closest('.field-box') === null) {
+      setSelectedField(null);
+    }
+  };
 
   // Initialize pageRefs when totalPages changes
   useEffect(() => {
@@ -136,7 +144,6 @@ export const FormEditor = ({
           ],
         ]),
       });
-      setHighlightedField(id);
       setSelectedField(null);
     }
   };
@@ -164,7 +171,6 @@ export const FormEditor = ({
           ],
         ]),
       });
-      setHighlightedField(id);
       setSelectedField(null);
     }
   };
@@ -192,7 +198,6 @@ export const FormEditor = ({
           ],
         ]),
       });
-      setHighlightedField(id);
       setSelectedField(null);
     }
   };
@@ -287,6 +292,7 @@ export const FormEditor = ({
       flexDir="column"
       gap="20px"
       width="100%"
+      onClick={handleDocumentClick}
     >
       {!disableEdit && (
         <Box display="flex" gap="12px" justifyContent={'flex-start'}>
@@ -502,7 +508,6 @@ export const FormEditor = ({
                                 data: DraggableData,
                               ) => {
                                 setSelectedField(fieldId);
-                                setHighlightedField(fieldId);
 
                                 handleFieldUpdate(groupId, fieldId, {
                                   width: position.width,
@@ -519,7 +524,6 @@ export const FormEditor = ({
                                 pos,
                               ) => {
                                 setSelectedField(fieldId);
-                                setHighlightedField(fieldId);
 
                                 let newWidth = parseFloat(
                                   elementRef.style.width,
@@ -541,7 +545,7 @@ export const FormEditor = ({
                               }}
                               disableEdit={disableEdit}
                               selected={selectedField === fieldId}
-                              highlighted={highlightedField === fieldId}
+                              highlighted={selectedField === fieldId}
                             />
                           ),
                         )}

--- a/apps/web/src/components/createFormTemplate/createFormTemplateEditor/SignatureField.tsx
+++ b/apps/web/src/components/createFormTemplate/createFormTemplateEditor/SignatureField.tsx
@@ -31,6 +31,7 @@ export default function SignatureField({
       minWidth={!disableEdit ? '150px' : ''}
       minHeight={!disableEdit ? '50px' : ''}
       border={selected ? `1px solid blue` : ''}
+      className="field-box"
       style={{
         zIndex: 10,
         background: `${color}`,

--- a/apps/web/src/components/createFormTemplate/createFormTemplateEditor/TextField.tsx
+++ b/apps/web/src/components/createFormTemplate/createFormTemplateEditor/TextField.tsx
@@ -31,6 +31,7 @@ export default function TextField({
       minWidth={!disableEdit ? '50px' : ''}
       minHeight={!disableEdit ? '10px' : ''}
       border={selected ? `1px solid blue` : ''}
+      className="field-box"
       style={{
         zIndex: 10,
         background: `${color}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When clicking off of a field box in assign-groups in create form template flow, deselect the currently selected field box.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes [#<!--Insert issue # here-->]

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
